### PR TITLE
Set background-color on canvas

### DIFF
--- a/src/jSignature.js
+++ b/src/jSignature.js
@@ -1094,6 +1094,8 @@ jSignatureClass.prototype.initializeCanvas = function(settings) {
 	    '-ms-touch-action'
 	    , 'none'
 	);
+	
+	$canvas.css('background-color', settings['background-color']);
 
 	$canvas.appendTo(this.$parent);
 


### PR DESCRIPTION
Currently, the background color of the canvas is not set on the canvas. This fixes it

Note:
The correct setting name is `background-color`, not `bgcolor`.

(this has to be fixed in http://www.unbolt.net/jSignature/)
