### PR TITLE
Using setData with the png/jpeg/jpg image types will now not add an addi...

### DIFF
--- a/src/jSignature.js
+++ b/src/jSignature.js
@@ -1270,12 +1270,16 @@ var GlobalJSignatureObjectInitializer = function(window){
 		// this = Canvas DOM elem. Not jQuery object. Not Canvas's parent div.
 		, c = this;
 
-		img.onload = function() {
-			var ctx = c.getContext("2d").drawImage( 
+		img.onload = function () {
+		    var ctx = c.getContext("2d");
+		    var oldShadowColor = ctx.shadowColor;
+            ctx.shadowColor = "transparent";
+		    ctx.drawImage( 
 				img, 0, 0
 				, ( img.width < c.width) ? img.width : c.width
 				, ( img.height < c.height) ? img.height : c.height
 			);
+		    ctx.shadowColor = oldShadowColor;
 		};
 
 		img.src = 'data:' + formattype + ',' + data;


### PR DESCRIPTION
This fixes an issue where using setData with png/jpeg/jpg data would cause an additional shadow to be placed on the jSignature canvas. This issue would for example prevent perfect duplication of signatures from one jSignature pad to another by getData'ing and setData'ing between them when using an image data format.
