### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "homepage": "https://github.com/brinley/jSignature",
   "description": "jQuery plugin for handling digital signatures",
-  "main": "jSignature.js",
+  "main": "src/jSignature.js",
   "keywords": [
     "jSignature",
     "signature",


### PR DESCRIPTION
Grunt tasks like bower-install look for the "main" attribute to know where to locate the file. The current bower.json says the file is located in the root directory, not the src directory.
