### PR TITLE
Update bower.json for https://github.com/brinley/jSignature/issues/65

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,12 @@
   "version": "2.0.0",
   "homepage": "https://github.com/brinley/jSignature",
   "description": "jQuery plugin for handling digital signatures",
-  "main": "src/jSignature.js",
+  "main": [
+    "src/jSignature.js",
+    "src/plugins/jSignature.CompressorBase30.js",
+    "src/plugins/jSignature.CompressorSVG.js",
+    "src/plugins/jSignature.UndoButton.js",
+  ],
   "keywords": [
     "jSignature",
     "signature",


### PR DESCRIPTION
This commit updates the bower.json main files to pull in the correct plugins.

If this is merged, can you also create a tag/release for v2.0.0 so bower can pick up the version?
