### PR TITLE
Add logic in .Net for converting from native jSignature to Base30 format

### DIFF
--- a/extras/SignatureDataConversion_dotNet/core/converter_alphanum_base30.cs
+++ b/extras/SignatureDataConversion_dotNet/core/converter_alphanum_base30.cs
@@ -197,7 +197,15 @@ namespace jSignature.Tools
             }
             return ss.ToArray();
         }
-		
+
+        /// <summary>
+        /// Returns a compressed string like this one: 
+        ///  "3E13Z5Y5_1O24Z66_1O1Z3_3E2Z4"
+        /// Originating from a stroke list such as:
+        ///  [[[100,50],[1,2],[3,4],[-5,-6],[5,-6]], [[50,100],[1,2],[-3,-4]]]
+        /// </summary>
+        /// <param name="data">.Net-specific structure (of array or arrays of arrays)</param>
+        /// <returns></returns>
         public string NativeToBase30(int[][][] data)
         {
             StringBuilder sb = new StringBuilder();

--- a/extras/SignatureDataConversion_dotNet/core/converter_alphanum_base30.cs
+++ b/extras/SignatureDataConversion_dotNet/core/converter_alphanum_base30.cs
@@ -182,7 +182,7 @@ namespace jSignature.Tools
         /// </summary>
         /// <param name="data">string of data encoded in base30 format. Ex: "3E13Z5Y5_1O24Z66_1O1Z3_3E2Z4"</param>
         /// <returns></returns>
-        public int[][][] GetData(string data){
+        public int[][][] Base30ToNative(string data){
             List<int[][]> ss = new List<int[][]>();
 
             string[] parts = data.Split('_');

--- a/extras/SignatureDataConversion_dotNet/tests/converter_alphanum_base30_TESTS.cs
+++ b/extras/SignatureDataConversion_dotNet/tests/converter_alphanum_base30_TESTS.cs
@@ -89,7 +89,7 @@ namespace jSignature.Tools.Tests
 
             Assert.AreEqual(
                 shouldbe
-                , c.GetData("3E13Z5Y5_1O24Z66_1O1Z3_3E2Z4")
+                , c.Base30ToNative("3E13Z5Y5_1O24Z66_1O1Z3_3E2Z4")
             );
         }
 
@@ -102,7 +102,7 @@ namespace jSignature.Tools.Tests
             Base30Converter bc = new Base30Converter();
 
             //Perform the decompression
-            int[][][] dec = bc.GetData(compressedSig);
+            int[][][] dec = bc.Base30ToNative(compressedSig);
 
             //Now convert the output back to being compressed
             string comp = bc.NativeToBase30(dec);

--- a/extras/SignatureDataConversion_dotNet/tests/converter_alphanum_base30_TESTS.cs
+++ b/extras/SignatureDataConversion_dotNet/tests/converter_alphanum_base30_TESTS.cs
@@ -92,5 +92,23 @@ namespace jSignature.Tools.Tests
                 , c.GetData("3E13Z5Y5_1O24Z66_1O1Z3_3E2Z4")
             );
         }
+
+        [Test]
+        public void id003_DecompressSigCompressSig()
+        {
+            //The sample signature will be decompressed and then compression will take place 
+            //immediately after that.  The end result should be identical to the input.
+            string compressedSig = "4A8865240Z12020020110200Y1442346668865543232010Z14854Y3858a77d65653212001301002544463334324_1TZ243532Ydgeglgb9646Z7ajicob74522000Y114465865a5511016a7c7a5a410Z15463566Y3545541111Z1332653Y1_bS2Z112344200Y25845583464662200Z40000002330Y216333343234_5DZ374331Y3a8667a5110Z34abfbc896Y4885885333Z5351Y233553332_aF_3K";
+            Base30Converter bc = new Base30Converter();
+
+            //Perform the decompression
+            int[][][] dec = bc.GetData(compressedSig);
+
+            //Now convert the output back to being compressed
+            string comp = bc.NativeToBase30(dec);
+
+            //The orignal input should be the same as our latest result
+            Assert.AreEqual(compressedSig, comp);
+        }
     }
 }

--- a/extras/SignatureDataConversion_dotNet/tests/converter_toSVG_TESTS.cs
+++ b/extras/SignatureDataConversion_dotNet/tests/converter_toSVG_TESTS.cs
@@ -106,7 +106,7 @@ namespace jSignature.Tools.Tests
         [Test]
         public void id003_ToSVG_External()
         {
-            var data = new jSignature.Tools.Base30Converter().GetData("3E13Z5Y5_1O24Z66_1O1Z3_3E2Z4");
+            var data = new jSignature.Tools.Base30Converter().Base30ToNative("3E13Z5Y5_1O24Z66_1O1Z3_3E2Z4");
 
             string actual = jSignature.Tools.SVGConverter.ToSVG(data);
 

--- a/extras/SignatureDataConversion_dotNet/tests/imagetools_Stats_TESTS.cs
+++ b/extras/SignatureDataConversion_dotNet/tests/imagetools_Stats_TESTS.cs
@@ -47,7 +47,7 @@ namespace jSignature.Tools.Tests
         public void id001_Sizes()
         {
             var c = new jSignature.Tools.Base30Converter();
-            var uncompresseddataobject = c.GetData(compressedtestdata);
+            var uncompresseddataobject = c.Base30ToNative(compressedtestdata);
             var stats = new jSignature.Tools.Stats(uncompresseddataobject);
 
             // above sig has the following limits


### PR DESCRIPTION
In the original .Net implementation, there was logic for going from Base30 to a Native coordinate format but the converse of that which was to go from Native to Base30 was missing.  This patch will give the ability to go for the full round trip.