### PR TITLE
add php classes to composers autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
     "name": "brinley/jsignature",
     "description": "Signature For Javascript",
-    "keywords": ["signature","jquery"],
+    "keywords": [
+        "signature",
+        "jquery"
+    ],
     "homepage": "http://www.unbolt.net/jSignature",
     "license": "MIT",
     "authors": [
@@ -10,9 +13,14 @@
             "role": "Developer"
         }
     ],
+    "autoload": {
+        "classmap": [
+            "extras/SignatureDataConversion_PHP/core/"
+        ]
+    },
     "extra": {
-    "branch-alias": {
-      "dev-master": "master"
+        "branch-alias": {
+            "dev-master": "master"
+        }
     }
-  }
 }


### PR DESCRIPTION
Please also consider registering package into [packagist registry](https://packagist.org/packages/submit), so we don't have to specify the repository.


```
>>> include 'vendor/autoload.php';
=> Composer\Autoload\ClassLoader {#193}
>>> new jSignature_Tools_Base30();
=> jSignature_Tools_Base30 {#186}
```