### PR TITLE
Remove closePath()

### DIFF
--- a/src/jSignature.js
+++ b/src/jSignature.js
@@ -467,14 +467,12 @@ var basicDot = function(ctx, x, y, size){
 	ctx.beginPath();
 	ctx.moveTo(startx, starty);
 	ctx.lineTo(endx, endy);
-	ctx.closePath();
 	ctx.stroke();
 }
 , basicCurve = function(ctx, startx, starty, endx, endy, cp1x, cp1y, cp2x, cp2y){
 	ctx.beginPath();
 	ctx.moveTo(startx, starty);
 	ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, endx, endy);
-	ctx.closePath();
 	ctx.stroke();
 }
 , strokeStartCallback = function(stroke) {


### PR DESCRIPTION
closePath "attempts to add a straight line from the current point to the start of the current sub-path" so for a straight line it does nothing, and for a curve it draws back to the start point so if you draw quickly you get an ugly two line effect.

![image](https://user-images.githubusercontent.com/12475567/192981593-b6198e32-d6f0-44e4-bbb4-b9f8c59b58c2.png)
